### PR TITLE
fix(ci): fix "actions/labeler" failing on PRs from forked repos

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -6,7 +6,7 @@
 # https://github.com/actions/labeler
 
 name: Labeler
-on: [pull_request]
+on: [pull_request_target]
 
 jobs:
   label:


### PR DESCRIPTION
Currently the Github Actions "Labeler" is failing on all PRs submitted **from a fork of this repository**.
This is explained here: https://github.com/actions/labeler/pull/50

The problem can be fixed by changing the type of event in:
https://github.com/sfeir-open-source/hacktoberfest-2020/blob/66ef37f1fbdd05b324c95d2115bd1e23a2f0ea5c/.github/workflows/label.yml#L9

by the new event type: **pull_request_target**

More information here: https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/#improvements-for-public-repository-forks